### PR TITLE
Use ISO dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ prompt.get(schema, (err, result) => {
 		  fs.writeFileSync(jsonpath, JSON.stringify(module));
 		  const downloads = lectures
           .sort((lec1, lec2) => moment(lec1.json.lesson.timing.start).isBefore(lec2.json.lesson.timing.start) ? -1 : 1)
-          .map((lecture, i) => Object.assign(lecture, {i, filename: `${query}-${i}-${moment(lecture.json.lesson.timing.start).format("hhaDoMMMYYYY")}.mp4`}))
+          .map((lecture, i) => Object.assign(lecture, {i, filename: `${query}-${i}-${moment(lecture.json.lesson.timing.start).format("YYYYMMDD-HHmm")}.mp4`}))
           .filter(lecture => {
             return exists.indexOf(lecture.filename) === -1 && !!lecture.sd;
           })

--- a/readme.md
+++ b/readme.md
@@ -22,19 +22,19 @@ For module input `["text", "speech", "graphics"]` and outpath `videos` you will 
 videos/
   text/
     text.json
-    text-0-11am26thSep2016.mp4
+    text-0-20160926-1100.mp4
     ...
-    text-9-03pm31stOct2017.mp4
+    text-9-20171031-1500.mp4
   speech/
     speech.json
-    speech-0-04pm26thSep2017.mp4
+    speech-0-20170926-1600.mp4
     ...
-    speech-9-04pm26thOct2017.mp4
+    speech-9-20171026-1600.mp4
   graphics/
     graphics.json
-    graphics-0-03pm25thSep2017.mp4
+    graphics-0-20170925-1500.mp4
     ...
-    graphics-9-11am23rdOct2017.mp4
+    graphics-9-20171023-1100.mp4
 ```
 It outputs A LOT of JSON data in the module json files.
 I suggest using [jq](https://stedolan.github.io/jq/) to simplify the output


### PR DESCRIPTION
Prefer use of ISO dates for filenames for ease of sorting. Didn't use toISOString as that includes colon characters by default.